### PR TITLE
Fixing not networked swing effects

### DIFF
--- a/RedGuyProject/SkillStates/BaseStates/BaseMeleeAttack.cs
+++ b/RedGuyProject/SkillStates/BaseStates/BaseMeleeAttack.cs
@@ -115,7 +115,7 @@ namespace RedGuyMod.SkillStates.BaseStates
 
         protected virtual void PlaySwingEffect()
         {
-            EffectManager.SimpleMuzzleFlash(this.swingEffectPrefab, base.gameObject, this.muzzleString, true);
+            EffectManager.SimpleMuzzleFlash(this.swingEffectPrefab, base.gameObject, this.muzzleString, false);
         }
 
         protected virtual void OnHitEnemyAuthority(int amount)
@@ -148,9 +148,10 @@ namespace RedGuyMod.SkillStates.BaseStates
                 this.hasFired = true;
                 Util.PlayAttackSpeedSound(this.swingSoundString, base.gameObject, this.attackSpeedStat);
 
+                this.PlaySwingEffect();
+
                 if (base.isAuthority)
                 {
-                    this.PlaySwingEffect();
                     base.AddRecoil(-1f * this.attackRecoil, -2f * this.attackRecoil, -0.5f * this.attackRecoil, 0.5f * this.attackRecoil);
                 }
             }


### PR DESCRIPTION
you've changed in your slash from the muzzleflash of old henry to a gameobject.spawn like the game so pulled it out of authority since it needs to happen on all machines now.

also I believe your `fuck.newDuration = fuck.initialDuration` doesn't do anything. that code is in the game's basicmeleeattack so it can be extended in hitstop

love ya